### PR TITLE
Add and use query-string package to support nested param url encoding

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,6 +3,7 @@ var url = require('url');
 var request = require('./request');
 var Promise = require('q').Promise;
 var packageJson = require('../package.json');
+var query = require('qs');
 
 function Api(config) {
 	this.config = _.defaults(config || {}, {
@@ -51,7 +52,7 @@ Api.prototype._request = function _request(opts) {
 		// Configure Parameters
 		if (_.isNumber(opts.startElement)) { opts.params.start_element = opts.startElement; }
 		if (_.isNumber(opts.numElements)) { opts.params.num_elements = opts.numElements; }
-		params = _.keys(opts.params).map(function (key) { return key + '=' + opts.params[key]; }).join('&');
+		params = decodeURIComponent(query.stringify(opts.params));
 		if (params !== '') {
 			opts.uri += (opts.uri.indexOf('?') === -1) ? '?' : '&';
 			opts.uri += params;

--- a/lib/api.mspec.js
+++ b/lib/api.mspec.js
@@ -55,7 +55,17 @@ describe('Api', function () {
 					startElement: 100,
 					numElements: 25,
 					params: {
-						myParam: 'value'
+						myParam: 'value',
+						myStdArray: [
+							1,
+							2,
+							3
+						],
+						myObjArray: [{
+							a: 'apple',
+						}, {
+							b: 'bee'
+						}]
 					}
 				});
 			});
@@ -70,6 +80,14 @@ describe('Api', function () {
 
 			it('uri should contain params', function () {
 				assert(_.contains(opts.uri, 'myParam=value'));
+			});
+
+			it('uri should convert standard nested array params', function() {
+				assert(_.contains(opts.uri, 'myStdArray[0]=1&myStdArray[1]=2&myStdArray[2]=3'));
+			});
+
+			it('uri should convert nested object array params', function() {
+				assert(_.contains(opts.uri, 'myObjArray[0][a]=apple&myObjArray[1][b]=bee'));
 			});
 
 		});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,45 +1,55 @@
 {
   "name": "anx-api",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "dependencies": {
     "lodash": {
       "version": "2.4.1",
-      "from": "lodash@"
+      "from": "lodash@2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
     },
     "q": {
       "version": "1.1.1",
-      "from": "q@",
+      "from": "https://registry.npmjs.org/q/-/q-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.1.1.tgz"
+    },
+    "qs": {
+      "version": "2.3.3",
+      "from": "qs@",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
     },
     "request": {
       "version": "2.48.0",
-      "from": "request@",
+      "from": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.48.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.3",
-          "from": "bl@~0.9.0",
+          "from": "bl@0.9.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@~1.0.26",
+              "from": "readable-stream@1.0.33",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0"
+                  "from": "core-util-is@1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x"
+                  "from": "string_decoder@0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1"
+                  "from": "inherits@2.0.1"
                 }
               }
             }
@@ -47,122 +57,135 @@
         },
         "caseless": {
           "version": "0.7.0",
-          "from": "caseless@~0.7.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.7.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0"
+          "from": "forever-agent@0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "form-data@~0.1.0",
+          "from": "form-data@0.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.11"
+              "from": "mime@1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@~0.9.0"
+              "from": "async@0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0"
+          "from": "json-stringify-safe@5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
-          "from": "mime-types@~1.0.1"
+          "from": "mime-types@1.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0"
-        },
-        "qs": {
-          "version": "2.3.3",
-          "from": "qs@~2.3.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+          "from": "node-uuid@1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@~0.4.0"
+          "from": "tunnel-agent@0.4.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "tough-cookie@0.12.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@>=0.2.0"
+              "from": "punycode@1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@~0.10.0",
+          "from": "http-signature@0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.5.0",
-          "from": "oauth-sign@~0.5.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
         },
         "hawk": {
           "version": "1.1.1",
-          "from": "hawk@1.1.1",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.2",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.2",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.4",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0"
+          "from": "aws-sign2@0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "stringstream@~0.0.4"
+          "from": "stringstream@0.0.4",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
-          "from": "combined-stream@~0.0.5",
+          "from": "combined-stream@0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "0.0.5",
-              "from": "delayed-stream@0.0.5",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "lodash": "^2.4.1",
     "q": "^1.1.1",
+    "qs": "^2.3.3",
     "request": "^2.48.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Enable nested param encoding with node-querystring, aka qs. This type of nesting is needed for requests to services like rapid-reports. 

e.g.

``` javascript
params: {
    "report_type":"rr_buyer_analytics_daily",
    "filters":[
        {
            "io_id":107040
        }
    ],
    "orders": [
        {
            "order_by":"day",
            "direction":"ASC"
        }
    ],
    "columns": [
        "day",
        "booked_revenue",
        "booked_revenue_adv_curr",
        "imps",
        "media_cost",
        "clicks",
        "total_convs"
    ],
    "timezone":"EST5EDT",
    "start_date":"2014-02-10",
    "end_date":"2014-03-08"
}
```
