### PR TITLE
Adds the original request options to the response body for consumers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -142,6 +142,8 @@ function __request(opts) {
 				return reject(errors.buildError(reqOpts, newRes));
 			}
 
+			newRes.req = reqOpts;
+
 			return resolve(newRes);
 		}).catch(function failure(err) {
 			var newErr;

--- a/lib/api.spec.js
+++ b/lib/api.spec.js
@@ -67,6 +67,10 @@ describe('AnxApi', function() {
 					expect(opts.timeout).toBe(60000);
 				});
 
+				it('should attach original request options to the response', function() {
+					expect(res.req).toEqual(opts);
+				});
+
 			});
 
 			describe('with invalid config', function() {


### PR DESCRIPTION
Useful for consumers to potentially see the original request in the downstream `then`'s for debugging/introspection.