### PR TITLE
Allow optional encodeParams config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 npm-debug.log
 coverage
+
+# Runtime data
+*.lock

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ config[object]:
 * `timeout` - (integer) optional request timeout in milliseconds (default: 60000) Triggers `ConnectionAbortedError` error.
 * `userAgent` - (string) optional user agent
 * `rateLimiting` - (boolean) optional rate limiting
+* `encodeParams` - (boolean) optional whether or not params should be encoded. (default: false)
 * `concurrencyLimit` - (integer) optional max concurrent requests
 * `beforeRequest` - (function) optional before request opts filter (see [beforeRequest](#beforerequest))
 * `afterRequest` - (function) optional after request response filter (see [afterRequest](#afterrequest))

--- a/lib/api.js
+++ b/lib/api.js
@@ -95,7 +95,7 @@ function __request(opts) {
 			reqOpts.params.start_element = +opts.startElement || reqOpts.params.start_element || 0; // startElement is required if numElements is set
 		}
 
-		params = decodeURIComponent(query.stringify(reqOpts.params));
+		params = query.stringify(reqOpts.params, {encode: _self._config.encodeParams});
 
 		if (params !== '') {
 			reqOpts.uri += (opts.uri.indexOf('?') === -1) ? '?' : '&';
@@ -165,6 +165,7 @@ function AnxApi(config) {
 		token: null,
 		rateLimiting: true,
 		chunkSize: DEFAULT_CHUNK_SIZE,
+		encodeParams: false,
 	});
 
 	this.request = __request;

--- a/lib/api.spec.js
+++ b/lib/api.spec.js
@@ -93,59 +93,93 @@ describe('AnxApi', function() {
 		describe('Options', function() {
 			var opts;
 
-			beforeEach(function(done) {
-				opts = null;
-				var api = new AnxApi({
-					target: 'http://example.com',
-					rateLimiting: false,
-					request: function(o) {
-						opts = o;
-						done();
-					},
+			describe('with encodeParams defaulted to false', function() {
+
+				beforeEach(function(done) {
+					opts = null;
+					var api = new AnxApi({
+						target: 'http://example.com',
+						rateLimiting: false,
+						request: function(o) {
+							opts = o;
+							done();
+						},
+					});
+					api.get({
+						uri: 'user',
+						timeout: 5000,
+						startElement: 100,
+						numElements: 25,
+						params: {
+							myParam: 'value',
+							myStdArray: [
+								1,
+								2,
+								3,
+							],
+							myObjArray: [{
+								a: 'apple',
+							}, {
+								b: 'bee',
+							}],
+						},
+					});
 				});
-				api.get({
-					uri: 'user',
-					timeout: 5000,
-					startElement: 100,
-					numElements: 25,
-					params: {
-						myParam: 'value',
-						myStdArray: [
-							1,
-							2,
-							3,
-						],
-						myObjArray: [{
-							a: 'apple',
-						}, {
-							b: 'bee',
-						}],
-					},
+
+				it('uri should contain start_element', function() {
+					assert(_.includes(opts.uri, 'start_element=100'));
 				});
+
+				it('uri should contain num_elements', function() {
+					assert(_.includes(opts.uri, 'num_elements=25'));
+				});
+
+				it('uri should contain params', function() {
+					assert(_.includes(opts.uri, 'myParam=value'));
+				});
+
+				it('uri should convert standard nested array params', function() {
+					assert(_.includes(opts.uri, 'myStdArray[0]=1&myStdArray[1]=2&myStdArray[2]=3'));
+				});
+
+				it('uri should convert nested object array params', function() {
+					assert(_.includes(opts.uri, 'myObjArray[0][a]=apple&myObjArray[1][b]=bee'));
+				});
+
+				it('should default request timeout', function() {
+					assert.equal(opts.timeout, 5000);
+				});
+
 			});
 
-			it('uri should contain start_element', function() {
-				assert(_.includes(opts.uri, 'start_element=100'));
-			});
+			describe('with encodeParams true', function() {
 
-			it('uri should contain num_elements', function() {
-				assert(_.includes(opts.uri, 'num_elements=25'));
-			});
+				beforeEach(function(done) {
+					opts = null;
+					var api = new AnxApi({
+						target: 'http://example.com',
+						rateLimiting: false,
+						request: function(o) {
+							opts = o;
+							done();
+						},
+						encodeParams: true,
+					});
+					api.get({
+						uri: 'user',
+						timeout: 5000,
+						startElement: 100,
+						numElements: 25,
+						params: {
+							myEncodedString: '%ssp',
+						},
+					});
+				});
 
-			it('uri should contain params', function() {
-				assert(_.includes(opts.uri, 'myParam=value'));
-			});
+				it('uri should encode params', function() {
+					assert(_.includes(opts.uri, 'myEncodedString=%25ssp'));
+				});
 
-			it('uri should convert standard nested array params', function() {
-				assert(_.includes(opts.uri, 'myStdArray[0]=1&myStdArray[1]=2&myStdArray[2]=3'));
-			});
-
-			it('uri should convert nested object array params', function() {
-				assert(_.includes(opts.uri, 'myObjArray[0][a]=apple&myObjArray[1][b]=bee'));
-			});
-
-			it('should default request timeout', function() {
-				assert.equal(opts.timeout, 5000);
 			});
 
 			describe('validation', function() {


### PR DESCRIPTION
Previously, anx-api always expected the `params` object values to be encoded. This PR allows you to specify an optional config flag, `encodeParams`, to pass in decoded param values.

`encodeParams` defaults to false in keeping with existing behavior.