### PR TITLE
Added optional `environment` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Latest
 
+## v4.4.0
+
+	[minor] Added optional `environment` config option
+
 ## v4.3.0
 
-	[minor] Added `encodeParams` option for params 
+	[minor] Added `encodeParams` option for params
 
 ## v4.2.0
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ config[object]:
 * `concurrencyLimit` - (integer) optional max concurrent requests
 * `beforeRequest` - (function) optional before request opts filter (see [beforeRequest](#beforerequest))
 * `afterRequest` - (function) optional after request response filter (see [afterRequest](#afterrequest))
+* `environment` - (enum:node|browser) optional. node - force axios to run as if in node and not the browser (usefull for testing with jest/jasmine).
 
 ## Instance Methods
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -158,7 +158,9 @@ function __request(opts) {
 
 function AnxApi(config) {
 	this._config = _.defaults({}, config, {
-		request: axiosAdapter,
+		request: axiosAdapter({
+			forceHttpAdaptor: config.environment === 'node',
+		}),
 		userAgent: 'anx-api/' + packageJson.version,
 		timeout: 60 * 1000,
 		headers: {},

--- a/lib/axiosAdapter.js
+++ b/lib/axiosAdapter.js
@@ -1,36 +1,42 @@
 var _ = require('lodash');
 var axios = require('axios');
+var httpAdapter = require('axios/lib/adapters/http');
 
-module.exports = function requestAdaptor(opts) {
-	var url = opts.uri;
-
-	var axiosOpts = {
-		timeout: opts.timeout,
-		method: opts.method.toLowerCase(),
-		headers: opts.headers,
-	};
-
-	if (!_.isUndefined(opts.body)) {
-		axiosOpts.data = opts.body;
-	}
-
-	var startTime = new Date().getTime();
-	return axios(url, axiosOpts, opts.body).then(function requestSuccess(res) {
-		return {
-			statusCode: res.status,
-			headers: res.headers,
-			body: res.data,
-			requestTime: new Date().getTime() - startTime,
+module.exports = function requestAdaptor(config) {
+	return function(opts) {
+		var url = opts.uri;
+		var axiosOpts = {
+			timeout: opts.timeout,
+			method: opts.method.toLowerCase(),
+			headers: opts.headers,
 		};
-	}).catch(function requestError(res) {
-		if (!res.response) {
-			throw res;
+
+		if (config.forceHttpAdaptor) {
+			axiosOpts.adapter = httpAdapter;
 		}
-		return {
-			statusCode: res.response.status,
-			headers: res.response.headers,
-			body: res.response.data,
-			requestTime: new Date().getTime() - startTime,
-		};
-	});
+
+		if (!_.isUndefined(opts.body)) {
+			axiosOpts.data = opts.body;
+		}
+
+		var startTime = new Date().getTime();
+		return axios(url, axiosOpts, opts.body).then(function requestSuccess(res) {
+			return {
+				statusCode: res.status,
+				headers: res.headers,
+				body: res.data,
+				requestTime: new Date().getTime() - startTime,
+			};
+		}).catch(function requestError(res) {
+			if (!res.response) {
+				throw res;
+			}
+			return {
+				statusCode: res.response.status,
+				headers: res.response.headers,
+				body: res.response.data,
+				requestTime: new Date().getTime() - startTime,
+			};
+		});
+	};
 };

--- a/lib/axiosAdapter.spec.js
+++ b/lib/axiosAdapter.spec.js
@@ -29,7 +29,7 @@ describe('Axios Adapter', function() {
 		};
 
 
-		return axiosAdapter(opts).then(function(res) {
+		return axiosAdapter({})(opts).then(function(res) {
 			assert.deepEqual(_.omit(res, 'requestTime'), {
 				statusCode: 200,
 				headers: { someHeader: 1 },
@@ -60,7 +60,7 @@ describe('Axios Adapter', function() {
 			uri: '/api/access-resource?num_elements=1000',
 		};
 
-		return axiosAdapter(opts).then(function(res) {
+		return axiosAdapter({})(opts).then(function(res) {
 			expect(res.statusCode).toBe(401);
 			expect(res.headers).toEqual({ someHeader: 1 });
 			expect(res.body).toEqual({ response: {} });


### PR DESCRIPTION
Fixes issue where using anx-api inside of Jest tests causes Jasmine timeouts