### PR TITLE
Bugfix/target url join

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "axios": "^0.15.0",
     "lodash": "^4.17.4",
-    "qs": "^6.2.1"
+    "qs": "^6.2.1",
+    "url-join": "^2.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import url from 'url';
 import query from 'qs';
 import urljoin from 'url-join';
 import errors from './errors';

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import url from 'url';
 import query from 'qs';
+import urljoin from 'url-join';
 import errors from './errors';
 import packageJson from '../package.json';
 import axiosAdapter from './axiosAdapter';
@@ -83,7 +84,7 @@ function __request(opts) {
 
 		reqOpts.headers = _.assign({}, reqOpts.headers, opts.headers);
 
-		reqOpts.uri = url.resolve(_self._config.target, _.trimStart(opts.uri, '/'));
+		reqOpts.uri = urljoin(_self._config.target, _.trimStart(opts.uri, '/'));
 
 		// Configure Parameters
 		if (_hasValue(opts.startElement)) {

--- a/src/api.spec.js
+++ b/src/api.spec.js
@@ -386,6 +386,50 @@ describe('AnxApi', function() {
 
 		});
 
+		describe('url formatting', () => {
+			it('should not alter the target URL', () => {
+				const finalRoute = 'http://example.com/route/sub-route';
+				const api = new AnxApi({
+					target: 'http://example.com/route',
+					rateLimiting: false,
+					request: function(opts) {
+						return Promise.resolve(opts);
+					},
+				});
+				return api.get('sub-route').then((opts) => {
+					return assert.equal(finalRoute, opts.uri);
+				});
+			});
+
+			it('should handle trailing slashes in the target URL', () => {
+				const finalRoute = 'http://example.com/route/sub-route';
+				const api = new AnxApi({
+					target: 'http://example.com/route/',
+					rateLimiting: false,
+					request: function(opts) {
+						return Promise.resolve(opts);
+					},
+				});
+				return api.get('sub-route').then((opts) => {
+					return assert.equal(finalRoute, opts.uri);
+				});
+			});
+
+			it('should trim off leading slashes on sub-routes', () => {
+				const finalRoute = 'http://example.com/route/sub-route';
+				const api = new AnxApi({
+					target: 'http://example.com/route',
+					rateLimiting: false,
+					request: function(opts) {
+						return Promise.resolve(opts);
+					},
+				});
+
+				return api.get('/sub-route').then((opts) => {
+					return assert.equal(finalRoute, opts.uri);
+				});
+			});
+		});
 	});
 
 	describe('#get', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,6 +3609,10 @@ unique-concat@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/unique-concat/-/unique-concat-0.2.2.tgz#9210f9bdcaacc5e1e3929490d7c019df96f18712"
 
+url-join@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.2.tgz#c072756967ad24b8b59e5741551caac78f50b8b7"
+
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"


### PR DESCRIPTION
When setting a target url, and it doesn't have a trailing slash, the generated `url` for the request is malformed. This addresses the issue by using the `url-join` package to properly handle URL concatenation