### PR TITLE
define types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
   "description": "AppNexus Api Wrapper",
   "homepage": "https://github.com/appnexus/anx-api",
   "bugs": "https://github.com/appnexus/anx-api/issues",
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "files": [
+    "lib",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/appnexus/anx-api.git"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "files": [
     "lib",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added the `types` field to package.json. I also specified which files to include in the library, namely `lib/`, `README.md`,  and `LICENSE`, to reduce the package size.